### PR TITLE
#39 - Social Media Images Block

### DIFF
--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -5,21 +5,13 @@ import styles from '/styles/Image.module.scss';
 import NextImage, { ImageProps } from 'next/image';
 
 export const Image = ({ className = '', ...props }: ImageProps) => {
-    // I've specified a default empty string value for alt text here
-    // So if you don't pass alt text into Image, it will assume the image is decorative.
-    let altText = '';
-    if (props.alt !== undefined) {
-        altText = props.alt;
+    if (!props.alt) {
+        props.alt = '';
     }
 
     return (
         <div className={styles.container}>
-            <NextImage
-                className={styles.image}
-                alt={altText}
-                layout="fill"
-                {...props}
-            />
+            <NextImage className={styles.image} layout="fill" {...props} />
         </div>
     );
 };

--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -1,0 +1,25 @@
+// Code taken from GitHub discussion thread on Next/Image
+// https://github.com/vercel/next.js/discussions/18739
+
+import styles from '/styles/Image.module.scss';
+import NextImage, { ImageProps } from 'next/image';
+
+export const Image = ({ className = '', ...props }: ImageProps) => {
+    // I've specified a default empty string value for alt text here
+    // So if you don't pass alt text into Image, it will assume the image is decorative.
+    let altText = '';
+    if (props.alt !== undefined) {
+        altText = props.alt;
+    }
+
+    return (
+        <div className={styles.container}>
+            <NextImage
+                className={styles.image}
+                alt={altText}
+                layout="fill"
+                {...props}
+            />
+        </div>
+    );
+};

--- a/components/SocialMediaPhotos.tsx
+++ b/components/SocialMediaPhotos.tsx
@@ -7,13 +7,13 @@ type SocialMediaPhotosProps = {
 };
 
 export const SocialMediaPhotos = ({ photos }: SocialMediaPhotosProps) => {
-    const SocialMediaPhotos = photos.slice(0, 8).map((image) => (
-        <li className={styles.image} key={image.description}>
+    const SocialMediaPhotos = photos.slice(0, 8).map((image, index) => (
+        <li className={styles.image} key={`social-media-image-${index}`}>
             <Image layout="fill" src={image.url} alt={image.description} />
         </li>
     ));
 
-    return <div className={styles.container}>{SocialMediaPhotos}</div>;
+    return <ul className={styles.container}>{SocialMediaPhotos}</ul>;
 };
 
 export default SocialMediaPhotos;

--- a/components/SocialMediaPhotos.tsx
+++ b/components/SocialMediaPhotos.tsx
@@ -1,0 +1,19 @@
+import { Image } from './Image';
+import styles from '/styles/SocialMediaPhotos.module.scss';
+import { ImageTypes } from 'types/Base';
+
+type SocialMediaPhotosProps = {
+    photos: ImageTypes[];
+};
+
+export const SocialMediaPhotos = ({ photos }: SocialMediaPhotosProps) => {
+    const SocialMediaPhotos = photos.slice(0, 8).map((image) => (
+        <li className={styles.image} key={image.description}>
+            <Image layout="fill" src={image.url} alt={image.description} />
+        </li>
+    ));
+
+    return <div className={styles.container}>{SocialMediaPhotos}</div>;
+};
+
+export default SocialMediaPhotos;

--- a/hooks/useMedia.tsx
+++ b/hooks/useMedia.tsx
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+
+export const useMedia = <T extends unknown>(queries: string[], values: T[], defaultValue: T) => {
+  // Array containing a media query list for each query
+  const mediaQueryLists = queries.map((q) => window.matchMedia(q));
+
+  // Function that gets value based on matching media query
+  const getValue = () => {
+    // Get index of first media query that matches
+    const index = mediaQueryLists.findIndex((mql) => mql.matches);
+    // Return related value or defaultValue if none
+    return values?.[index] || defaultValue;
+  };
+  // State and setter for matched value
+  const [value, setValue] = useState<T>(getValue);
+  useEffect(
+    () => {
+      // Event listener callback
+      // Note: By defining getValue outside of useEffect we ensure that it has ...
+      // ... current values of hook args (as this hook callback is created once on mount).
+      const handler = () => setValue(getValue);
+      // Set a listener for each media query with above handler as callback.
+      mediaQueryLists.forEach((mql) => mql.addListener(handler));
+      // Remove listeners on cleanup
+      return () =>
+        mediaQueryLists.forEach((mql) => mql.removeListener(handler));
+    },
+    [] // Empty array ensures effect is only run on mount and unmount
+  );
+  
+  return value;
+};

--- a/hooks/useMedia.tsx
+++ b/hooks/useMedia.tsx
@@ -1,32 +1,36 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
-export const useMedia = <T extends unknown>(queries: string[], values: T[], defaultValue: T) => {
-  // Array containing a media query list for each query
-  const mediaQueryLists = queries.map((q) => window.matchMedia(q));
+export const useMedia = <T extends unknown>(
+    queries: string[],
+    values: T[],
+    defaultValue: T,
+) => {
+    // Array containing a media query list for each query
+    const mediaQueryLists = queries.map((q) => window.matchMedia(q));
 
-  // Function that gets value based on matching media query
-  const getValue = () => {
-    // Get index of first media query that matches
-    const index = mediaQueryLists.findIndex((mql) => mql.matches);
-    // Return related value or defaultValue if none
-    return values?.[index] || defaultValue;
-  };
-  // State and setter for matched value
-  const [value, setValue] = useState<T>(getValue);
-  useEffect(
-    () => {
-      // Event listener callback
-      // Note: By defining getValue outside of useEffect we ensure that it has ...
-      // ... current values of hook args (as this hook callback is created once on mount).
-      const handler = () => setValue(getValue);
-      // Set a listener for each media query with above handler as callback.
-      mediaQueryLists.forEach((mql) => mql.addListener(handler));
-      // Remove listeners on cleanup
-      return () =>
-        mediaQueryLists.forEach((mql) => mql.removeListener(handler));
-    },
-    [] // Empty array ensures effect is only run on mount and unmount
-  );
-  
-  return value;
+    // Function that gets value based on matching media query
+    const getValue = () => {
+        // Get index of first media query that matches
+        const index = mediaQueryLists.findIndex((mql) => mql.matches);
+        // Return related value or defaultValue if none
+        return values?.[index] || defaultValue;
+    };
+    // State and setter for matched value
+    const [value, setValue] = useState<T>(getValue);
+    useEffect(
+        () => {
+            // Event listener callback
+            // Note: By defining getValue outside of useEffect we ensure that it has ...
+            // ... current values of hook args (as this hook callback is created once on mount).
+            const handler = () => setValue(getValue);
+            // Set a listener for each media query with above handler as callback.
+            mediaQueryLists.forEach((mql) => mql.addListener(handler));
+            // Remove listeners on cleanup
+            return () =>
+                mediaQueryLists.forEach((mql) => mql.removeListener(handler));
+        },
+        [], // Empty array ensures effect is only run on mount and unmount
+    );
+
+    return value;
 };

--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,7 @@ module.exports = {
         // allow all scss files access to these files
         prependData: `@use "sass:math"; @import "variables.scss"; @import "functions.scss"; @import "mixins.scss"; @import "fonts.scss"; `,
     },
+    images: {
+        domains: ['images.ctfassets.net', 'source.unsplash.com'],
+    },
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,7 @@ const PlaceholderImage = {
     height: 750,
 };
 
-const ImageArray = [...Array(10)].map((_, i) => PlaceholderImage);
+const ImageArray = [...Array(10)].map((_) => PlaceholderImage);
 
 const Home: NextPage = () => {
     return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,22 @@
 import type { NextPage } from 'next';
 import styles from 'styles/Home.module.scss';
 
+import SocialMediaPhotos from 'components/SocialMediaPhotos';
+
+const PlaceholderImage = {
+    description: 'This is a placeholder',
+    url: 'https://source.unsplash.com/random/750x750/?nature',
+    width: 750,
+    height: 750,
+};
+
+const ImageArray = [...Array(10)].map((_, i) => PlaceholderImage);
+
 const Home: NextPage = () => {
     return (
         <div className={styles.container}>
             <h1 className={styles.title}>Vercel Setup</h1>
+            <SocialMediaPhotos photos={ImageArray} />
         </div>
     );
 };

--- a/styles/Image.module.scss
+++ b/styles/Image.module.scss
@@ -1,0 +1,18 @@
+// Code taken from GitHub discussion thread on Next/Image
+// https://github.com/vercel/next.js/discussions/18739
+
+.container {
+    position: relative;
+    width: 100%;
+
+    & > span {
+        position: unset !important;
+    }
+}
+
+.image {
+    object-fit: contain;
+    width: 100% !important;
+    position: relative !important;
+    height: unset !important;
+}

--- a/styles/Image.module.scss
+++ b/styles/Image.module.scss
@@ -1,6 +1,3 @@
-// Code taken from GitHub discussion thread on Next/Image
-// https://github.com/vercel/next.js/discussions/18739
-
 .container {
     position: relative;
     width: 100%;

--- a/styles/SocialMediaPhotos.module.scss
+++ b/styles/SocialMediaPhotos.module.scss
@@ -3,6 +3,10 @@
     padding: 0 $grid;
     grid-template-columns: 1fr 1fr;
 
+    @include media-query(medium) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
     @include media-query(large) {
         padding: 0 $grid * 2;
         grid-template-columns: repeat(4, 1fr);

--- a/styles/SocialMediaPhotos.module.scss
+++ b/styles/SocialMediaPhotos.module.scss
@@ -1,0 +1,28 @@
+.container {
+    display: grid;
+    padding: 0 $grid;
+    grid-template-columns: 1fr 1fr;
+
+    @include media-query(large) {
+        padding: 0 $grid * 2;
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.image {
+    list-style-type: none;
+    border: 2px solid var(--color--white);
+
+    /* Hide the last two images on mobile */
+    &:nth-child(7n),
+    &:nth-child(8n) {
+        display: none;
+    }
+
+    @include media-query(large) {
+        &:nth-child(7n),
+        &:nth-child(8n) {
+            display: block;
+        }
+    }
+}

--- a/types/Base.ts
+++ b/types/Base.ts
@@ -1,0 +1,6 @@
+export type ImageTypes = {
+    description: string;
+    url: string;
+    width: number;
+    height: number;
+};


### PR DESCRIPTION
[Ticket on Codebase](https://projects.torchbox.com/projects/contentful-careers-page/tickets/39).

Adds the social media photo grid using a restyled version of the `NextImage` component. The cards shown on the mobile view are reduced to six as per specifications, I've decided to show three columns of images for tablet devices (see screenshot) and then the standard eight images for desktop.

Added padding internally as this component won't have page container padding.

### Screenshots
![image](https://user-images.githubusercontent.com/18164832/151158637-19cfda87-cd50-43e9-9755-591ac346eb46.png)
