### PR TITLE
#16 - Site Map Generator

### DIFF
--- a/pages/api/jobs/slugs.ts
+++ b/pages/api/jobs/slugs.ts
@@ -6,7 +6,7 @@ import { getAllJobPostings } from '../_peopleHR';
  * Used for generating pages in jobs/[slug].tsx
  * @returns an array of URL slugs for all the job posts.
  */
-export async function getAllJobSlugs(): Promise<(string | undefined)[] | null> {
+export async function getAllJobSlugs(): Promise<string[] | null> {
     const jobPostings: JobPost[] | null = await getAllJobPostings();
     if (jobPostings === null) return null;
     return jobPostings.map((post) => `/jobs/${post.slug}`);

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,20 +1,44 @@
 import { GetServerSideProps } from 'next';
+import { getAllJobSlugs } from './api/jobs/slugs';
 
-function generateSiteMap() {
-    const rootUrl = process.env.VERCEL_URL
-        ? process.env.VERCEL_URL
-        : 'http://localhost:3000';
+function generateSiteMap(jobSlugs: string[] | null) {
+    let baseUrl = 'http://localhost:3000';
+    if (process.env.VERCEL_ENV) {
+        baseUrl = {
+            production: 'https://torchbox.com/careers',
+            preview: process.env.VERCEL_URL,
+            development: 'http://localhost:3000',
+        }[process.env.VERCEL_ENV] as string;
+    }
+
     return `<?xml version="1.0" encoding="UTF-8"?>
-   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-     <url>
-       <loc>${rootUrl}</loc>
-     </url>
-   </urlset>
- `;
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+        <loc>${baseUrl}</loc>
+      </url>
+      <url>
+        <loc>${baseUrl + '/life-at-torchbox/'}</loc>
+      </url>
+      <url>
+        <loc>${baseUrl + '/jobs/'}</loc>
+      </url>
+      ${
+          jobSlugs &&
+          jobSlugs.map(
+              (slug: string) => `
+              <url>
+                <loc>${baseUrl + slug}</loc>
+              </url>
+            `,
+          )
+      }
+    </urlset>
+  `;
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-    const sitemap = generateSiteMap();
+    const jobSlugs = await getAllJobSlugs();
+    const sitemap = generateSiteMap(jobSlugs);
 
     context.res.setHeader('Content-Type', 'text/xml');
     context.res.write(sitemap);

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { getAllJobSlugs } from './api/jobs/slugs';
 
-function generateSiteMap(jobSlugs: string[] | null) {
+const generateSiteMap = (jobSlugs: string[] | null) => {
     let baseUrl = 'http://localhost:3000';
     if (process.env.VERCEL_ENV) {
         baseUrl = {
@@ -17,10 +17,10 @@ function generateSiteMap(jobSlugs: string[] | null) {
         <loc>${baseUrl}</loc>
       </url>
       <url>
-        <loc>${baseUrl + '/life-at-torchbox/'}</loc>
+        <loc>${baseUrl + '/life-at-torchbox'}</loc>
       </url>
       <url>
-        <loc>${baseUrl + '/jobs/'}</loc>
+        <loc>${baseUrl + '/jobs'}</loc>
       </url>
       ${
           jobSlugs &&
@@ -36,18 +36,18 @@ function generateSiteMap(jobSlugs: string[] | null) {
   `;
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     const jobSlugs = await getAllJobSlugs();
     const sitemap = generateSiteMap(jobSlugs);
 
-    context.res.setHeader('Content-Type', 'text/xml');
-    context.res.write(sitemap);
-    context.res.end();
+    res.setHeader('Content-Type', 'text/xml');
+    res.write(sitemap);
+    res.end();
 
     return {
         props: {},
     };
 };
 
-function SiteMap() {}
-export default SiteMap;
+const Sitemap = () => {};
+export default Sitemap;

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,4 +1,6 @@
 import { GetServerSideProps } from 'next';
+import { ServerResponse } from 'http';
+import fs from 'fs';
 import { getAllJobSlugs } from './api/jobs/slugs';
 
 const generateSiteMap = (jobSlugs: string[] | null) => {
@@ -11,30 +13,52 @@ const generateSiteMap = (jobSlugs: string[] | null) => {
         }[process.env.VERCEL_ENV] as string;
     }
 
+    const staticPages = fs
+        .readdirSync(process.env.VERCEL_ENV ? './.next/server/pages' : 'pages')
+        .filter((staticPage) => {
+            // Filter out unwanted folders and pages
+            return ![
+                'api',
+                'jobs',
+                'index.tsx',
+                '_app.tsx',
+                '_error.js',
+                '_error.js',
+                'sitemap.xml.ts',
+            ].includes(staticPage);
+        })
+        .map((staticPagePath) => {
+            const path = `${baseUrl}/${staticPagePath}`.replace('.tsx', '');
+            return path;
+        });
+
     return `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       <url>
         <loc>${baseUrl}</loc>
       </url>
-      <url>
-        <loc>${baseUrl + '/life-at-torchbox'}</loc>
-      </url>
-      <url>
-        <loc>${baseUrl + '/jobs'}</loc>
-      </url>
+      ${staticPages
+          .map(
+              (url) => `
+          <url>
+            <loc>${url}</loc>
+          </url>
+        `,
+          )
+          .join('')}
       ${
           jobSlugs &&
           jobSlugs.map(
               (slug: string) => `
-              <url>
-                <loc>${baseUrl + slug}</loc>
-              </url>
-            `,
+          <url>
+            <loc>${baseUrl + slug}</loc>
+          </url>
+        `,
           )
       }
     </urlset>
   `;
-}
+};
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     const jobSlugs = await getAllJobSlugs();


### PR DESCRIPTION
[Link to ticket on Codebase](https://projects.torchbox.com/projects/contentful-careers-page/tickets/16)

This ticket creates the sitemap of the website according to the pages generated by the peopleHR api integration. I haven't added future URLs such as `/employee-owned-trust/` or `/academy/` as these aren't implemented with pages yet, and this would cause errors with Pa11y CI.

To test this, go to `/sitemap.xml`