### PR TITLE
Change Link on Open to All Section of the Academy Page

### DIFF
--- a/components/Academy/OpenToAll/OpenToAll.tsx
+++ b/components/Academy/OpenToAll/OpenToAll.tsx
@@ -21,9 +21,9 @@ export const OpenToAll = ({ title, content, image }: OpenToAllProps) => {
                     content={content}
                     className={styles.content}
                 />
-                <Link href="/life-at-torchbox" scroll={false}>
+                <Link href="/" scroll={false}>
                     <a className="underline-link underline-link--white">
-                        Find out more about Life at Torchbox
+                        Find out more about Torchbox
                     </a>
                 </Link>
                 <div className={styles.background}></div>


### PR DESCRIPTION
No Codebase ticket, informal minor change requested by Lisa.

The link on the open to all component now leads to the Being at Torchbox page, to help users who have navigated directly to the Academy page to explore the rest of the careers site.

[Link to preview site page with component](https://careers-9q246q7qx-careers-site.vercel.app/careers/academy)

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
