### PR TITLE
Fix Subnav Underline and Mobile Nav Close

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -18,7 +18,7 @@ const NAVIGATION_LINKS = [
         title: 'Digital marketing',
         url: 'https://torchbox.com/digital-marketing/',
     },
-    { title: 'Jobs', url: '/jobs/', isCareersSiteInternalLink: true },
+    { title: 'Jobs', url: '/jobs', isCareersSiteInternalLink: true },
     {
         title: 'Being at Torchbox',
         url: '/',
@@ -85,6 +85,7 @@ export const Header = ({ jobsAvailable = 0 }: HeaderProps) => {
             </div>
             <MobileNav
                 isOpen={isOpen}
+                toggleMobileMenu={toggleMobileMenu}
                 links={NAVIGATION_LINKS}
                 navMenuRef={mobileNavRef}
                 jobsAvailable={jobsAvailable}

--- a/components/Navigation/DesktopSubnav/DesktopSubnav.module.scss
+++ b/components/Navigation/DesktopSubnav/DesktopSubnav.module.scss
@@ -33,11 +33,15 @@
         transition: all $transition-quick;
         color: var(--color--dark-indigo);
         display: inline-block;
-        padding-bottom: 2px;
+        padding-bottom: 0;
 
         &:hover,
-        &:focus,
-        &--active {
+        &:focus {
+            @include link-underscore(2);
+            color: var(--color--dark-indigo);
+        }
+
+        &.subnavLinkActive {
             @include link-underscore(2);
             color: var(--color--dark-indigo);
         }

--- a/components/Navigation/DesktopSubnav/DesktopSubnav.tsx
+++ b/components/Navigation/DesktopSubnav/DesktopSubnav.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useRef } from 'react';
 import { useRouter } from 'next/router';
 import { NavLink } from 'types/Base';
+import { pluralize } from 'lib/utilities';
 import styles from './DesktopSubnav.module.scss';
 
 type DesktopSubnavProps = {
@@ -103,7 +104,11 @@ export const DesktopSubnav = ({
                             <Link href="/jobs" scroll={false}>
                                 <a
                                     className={`${styles.subnavBadge} ${styles.badge}`}
-                                    aria-label={`${jobsAvailable} jobs available`}
+                                    aria-label={`${jobsAvailable} ${pluralize(
+                                        jobsAvailable,
+                                        'job',
+                                        's',
+                                    )} available`}
                                     tabIndex={-1}
                                 >
                                     {jobsAvailable}

--- a/components/Navigation/DesktopSubnav/DesktopSubnav.tsx
+++ b/components/Navigation/DesktopSubnav/DesktopSubnav.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { useRef } from 'react';
+import { useRouter } from 'next/router';
 import { NavLink } from 'types/Base';
 import styles from './DesktopSubnav.module.scss';
 
@@ -14,6 +15,7 @@ export const DesktopSubnav = ({
     jobsAvailable = 0,
     toggleMenu,
 }: DesktopSubnavProps) => {
+    const router = useRouter();
     // Use a ref as we don't need to rerender the component on tab navigation
     const keysPressedRef = useRef<Array<string>>([]);
 
@@ -72,10 +74,6 @@ export const DesktopSubnav = ({
                 ? handleLastItemKeyDown
                 : handleKeyDown;
 
-        // If the careers nav item is moved to the top of the list, you shouldn't tab out when shift tabbing the badge
-        const handleBadgeKeyDown =
-            index === links.length - 1 ? handleLastItemKeyDown : handleKeyDown;
-
         // If the careers nav item is at the bottom of the list, you shouldn't tab out until you tab through the badge
         const handleCareersKeyDown =
             index === 0 ? handleFirstItemKeyDown : handleKeyDown;
@@ -92,16 +90,18 @@ export const DesktopSubnav = ({
                             <a
                                 onKeyUp={handleKeyUp}
                                 onKeyDown={handleCareersKeyDown}
-                                className={styles.subnavLink}
+                                className={`${styles.subnavLink} ${
+                                    link.url === router.pathname
+                                        ? styles.subnavLinkActive
+                                        : null
+                                }`}
                             >
                                 {link.title}
                             </a>
                         </Link>
                         {link.title === 'Jobs' && jobsAvailable > 0 && (
-                            <Link href="/jobs/" scroll={false}>
+                            <Link href="/jobs" scroll={false}>
                                 <a
-                                    onKeyUp={handleKeyUp}
-                                    onKeyDown={handleBadgeKeyDown}
                                     className={`${styles.subnavBadge} ${styles.badge}`}
                                     aria-label={`${jobsAvailable} jobs available`}
                                     tabIndex={-1}

--- a/components/Navigation/MobileNav/MobileNav.tsx
+++ b/components/Navigation/MobileNav/MobileNav.tsx
@@ -1,47 +1,70 @@
 import Link from 'next/link';
-import { RefObject } from 'react';
+import React, { RefObject } from 'react';
+import { useRouter } from 'next/router';
 import { NavLink } from 'types/Base';
 import styles from './MobileNav.module.scss';
 
 type MobileNavItemProps = {
     link: NavLink;
+    toggleMobileMenu: (_: void) => void;
     jobsAvailable?: number;
 };
 
-const MobileNavItem = ({ jobsAvailable = 0, link }: MobileNavItemProps) => (
-    <li
-        className={`${styles.mobileNavItem} ${
-            link.title === 'Jobs' &&
-            jobsAvailable > 0 &&
-            styles.mobileNavItemWithBadge
-        }`}
-    >
-        {link.isCareersSiteInternalLink ? (
-            <Link href={link.url} scroll={false}>
-                <a className={styles.mobileNavItemLink}>
+const MobileNavItem = ({
+    jobsAvailable = 0,
+    toggleMobileMenu,
+    link,
+}: MobileNavItemProps) => {
+    const router = useRouter();
+    const redirectOrCloseMenu = (
+        event: React.MouseEvent<HTMLAnchorElement>,
+    ) => {
+        if (link.url === router.pathname) {
+            event.preventDefault();
+            toggleMobileMenu();
+        }
+    };
+    return (
+        <li
+            className={`${styles.mobileNavItem} ${
+                link.title === 'Jobs' &&
+                jobsAvailable > 0 &&
+                styles.mobileNavItemWithBadge
+            }`}
+        >
+            {link.isCareersSiteInternalLink ? (
+                <Link href={link.url} scroll={false}>
+                    <a
+                        className={styles.mobileNavItemLink}
+                        onClick={redirectOrCloseMenu}
+                    >
+                        <span className={styles.mobileNavItemTitle}>
+                            {link.title}
+                        </span>
+                        {link.title === 'Jobs' && jobsAvailable > 0 && (
+                            <span
+                                className={`${styles.mobileNavItemBadgeLink} ${styles.badge}`}
+                                aria-label={`${jobsAvailable} jobs available`}
+                            >
+                                {jobsAvailable}
+                            </span>
+                        )}
+                    </a>
+                </Link>
+            ) : (
+                <a className={styles.mobileNavItemLink} href={link.url}>
                     <span className={styles.mobileNavItemTitle}>
                         {link.title}
                     </span>
-                    {link.title === 'Jobs' && jobsAvailable > 0 && (
-                        <span
-                            className={`${styles.mobileNavItemBadgeLink} ${styles.badge}`}
-                            aria-label={`${jobsAvailable} jobs available`}
-                        >
-                            {jobsAvailable}
-                        </span>
-                    )}
                 </a>
-            </Link>
-        ) : (
-            <a className={styles.mobileNavItemLink} href={link.url}>
-                <span className={styles.mobileNavItemTitle}>{link.title}</span>
-            </a>
-        )}
-    </li>
-);
+            )}
+        </li>
+    );
+};
 
 type MobileNavProps = {
     navMenuRef: RefObject<HTMLDivElement>;
+    toggleMobileMenu: (_: void) => void;
     isOpen: boolean;
     links: NavLink[];
     jobsAvailable?: number;
@@ -49,12 +72,18 @@ type MobileNavProps = {
 
 export const MobileNav = ({
     navMenuRef,
+    toggleMobileMenu,
     isOpen,
     links,
     jobsAvailable = 0,
 }: MobileNavProps) => {
     const navItems = links.map((link, index) => (
-        <MobileNavItem link={link} jobsAvailable={jobsAvailable} key={index} />
+        <MobileNavItem
+            link={link}
+            jobsAvailable={jobsAvailable}
+            key={index}
+            toggleMobileMenu={toggleMobileMenu}
+        />
     ));
 
     return (

--- a/components/Navigation/MobileNav/MobileNav.tsx
+++ b/components/Navigation/MobileNav/MobileNav.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import React, { RefObject } from 'react';
 import { useRouter } from 'next/router';
 import { NavLink } from 'types/Base';
+import { pluralize } from 'lib/utilities';
 import styles from './MobileNav.module.scss';
 
 type MobileNavItemProps = {
@@ -44,7 +45,11 @@ const MobileNavItem = ({
                         {link.title === 'Jobs' && jobsAvailable > 0 && (
                             <span
                                 className={`${styles.mobileNavItemBadgeLink} ${styles.badge}`}
-                                aria-label={`${jobsAvailable} jobs available`}
+                                aria-label={`${jobsAvailable} ${pluralize(
+                                    jobsAvailable,
+                                    'job',
+                                    's',
+                                )} available`}
                             >
                                 {jobsAvailable}
                             </span>
@@ -81,7 +86,7 @@ export const MobileNav = ({
         <MobileNavItem
             link={link}
             jobsAvailable={jobsAvailable}
-            key={index}
+            key={`mobile-nav-item-${index}`}
             toggleMobileMenu={toggleMobileMenu}
         />
     ));

--- a/lib/utilities.ts
+++ b/lib/utilities.ts
@@ -1,0 +1,2 @@
+export const pluralize = (count: number, noun: string, nounSuffix = 's') =>
+    `${count !== 1 ? noun + nounSuffix : noun}`;


### PR DESCRIPTION
Updated the subnav so that the current page being visited has an underline, matching the main site.

Now when you click on the current page in the mobile nav, the menu closes the reveal that page - before, the menu wouldn't respond.

### How to Test

[Link to preview site page with component]()

### Screenshots, Gifs

<details>
  <summary>Screenshots</summary>
  
<img width="1322" alt="Screenshot 2022-04-11 at 15 17 19" src="https://user-images.githubusercontent.com/18164832/162763173-87cfae30-2e31-40a7-9bb8-b1bc4b96c8b4.png">

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
