### PR TITLE
Fix Extra Slashes in Mailto Link

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,7 +31,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         );
         console.log('%cGet in Touch 📬', heading);
         console.log(
-            "You can email mailto://recruitment@torchbox.com for any careers enquiries\nWe're also on Twitter at https://twitter.com/torchbox",
+            "You can email mailto:recruitment@torchbox.com for any careers enquiries\nWe're also on Twitter at https://twitter.com/torchbox",
         );
     }, []);
 


### PR DESCRIPTION
Mailto links don't need `//`, this gets appended to the start of the email address. I've removed these slashes from the console message.

Sadly this removes the clickable link / link highlight effect from the Chrome console. Maybe this should be raised as an issue.

[Preview site](https://careers-qr5xtxucz-careers-site.vercel.app/careers).

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
