### PR TITLE
Fix Footer Color Contrast Accessibility Issue

### DIFF
--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -164,7 +164,7 @@
         display: block;
         line-height: 24px;
         font-weight: $weight--bold;
-        color: var(--color--coral-dark);
+        color: var(--color--coral-dark-accessible);
         margin-top: 8px;
 
         &:hover {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -7,6 +7,7 @@
 :root {
     --color--coral: #fd5765;
     --color--coral-dark: #eb0316;
+    --color--coral-dark-accessible: #e00517;
     --color--lagoon: #3beccd;
     --color--indigo: #2f128d;
     --color--dark-indigo: #251657;


### PR DESCRIPTION
### [Link to Ticket On Codebase](https://projects.torchbox.com/projects/contentful-careers-page/tickets/94)

### Description of Changes Made

Following an audit of the site using Google Lighthouse, one accessibility issue was raised for mobile devices - changing the colour contrast of the mobile phone link fixes this issue.

### How to Test

[Check the contrast on the preview site](https://careers-7v3ypaojl-careers-site.vercel.app/careers), also consider running this through Google Lighthouse with mobile device settings to verify no further accessibility audit changes are required.

### Screenshots

<details>
  <summary>Expand to show more</summary>
<img width="396" alt="image" src="https://user-images.githubusercontent.com/18164832/163987601-e65fa48d-5267-4efd-859d-37316936239e.png">

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
