### PR TITLE
Replace 'Apply now' Button on Academy Page

### DIFF
--- a/components/Academy/AcademyDayCards/AcademyDayCards.module.scss
+++ b/components/Academy/AcademyDayCards/AcademyDayCards.module.scss
@@ -83,3 +83,16 @@
     display: block;
     margin: 0 auto;
 }
+
+.disabledButton {
+    @include font-size(m);
+    background-color: var(--color--white);
+    border-radius: 7px;
+    color: var(--color--coral);
+    cursor: not-allowed;
+    display: block;
+    font-weight: $weight--extrabold;
+    width: max-content;
+    padding: 12px 20px 12px 20px;
+    margin: 20px auto 40px auto;
+}

--- a/components/Academy/AcademyDayCards/AcademyDayCards.tsx
+++ b/components/Academy/AcademyDayCards/AcademyDayCards.tsx
@@ -2,6 +2,7 @@ import { Document } from '@contentful/rich-text-types';
 import RichText from 'components/RichText';
 import MicrophonePerson from 'components/SVG/MicrophonePerson';
 import CoffeePerson from 'components/SVG/CoffeePerson';
+import Button from 'components/Button';
 import { CharacterType } from 'types/Base';
 import styles from './AcademyDayCards.module.scss';
 
@@ -12,7 +13,7 @@ type AcademyDay = {
     character: CharacterType;
 };
 
-const Card = ({ title, content, character }: AcademyDay) => (
+const Card = ({ title, content, link, character }: AcademyDay) => (
     <div className={styles.card}>
         <div className={styles.icon}>
             {character === 'MICROPHONE' ? (
@@ -25,12 +26,14 @@ const Card = ({ title, content, character }: AcademyDay) => (
         <h3 className={styles.title}>{title}</h3>
 
         <RichText theme="INDIGO" content={content} className={styles.content} />
-        {/*
-        <Button url={link} theme="WHITE" className={styles.button} internal>
-            Apply now
-        </Button>
-        */}
-        <div className={styles.disabledButton}>Applications closed</div>
+
+        {link !== '' ? (
+            <Button url={link} theme="WHITE" className={styles.button} internal>
+                Apply now
+            </Button>
+        ) : (
+            <div className={styles.disabledButton}>Applications closed</div>
+        )}
     </div>
 );
 

--- a/components/Academy/AcademyDayCards/AcademyDayCards.tsx
+++ b/components/Academy/AcademyDayCards/AcademyDayCards.tsx
@@ -27,7 +27,7 @@ const Card = ({ title, content, link, character }: AcademyDay) => (
 
         <RichText theme="INDIGO" content={content} className={styles.content} />
 
-        {link !== '' ? (
+        {link !== null ? (
             <Button url={link} theme="WHITE" className={styles.button} internal>
                 Apply now
             </Button>

--- a/components/Academy/AcademyDayCards/AcademyDayCards.tsx
+++ b/components/Academy/AcademyDayCards/AcademyDayCards.tsx
@@ -1,6 +1,5 @@
 import { Document } from '@contentful/rich-text-types';
 import RichText from 'components/RichText';
-import Button from 'components/Button';
 import MicrophonePerson from 'components/SVG/MicrophonePerson';
 import CoffeePerson from 'components/SVG/CoffeePerson';
 import { CharacterType } from 'types/Base';
@@ -13,7 +12,7 @@ type AcademyDay = {
     character: CharacterType;
 };
 
-const Card = ({ title, content, link, character }: AcademyDay) => (
+const Card = ({ title, content, character }: AcademyDay) => (
     <div className={styles.card}>
         <div className={styles.icon}>
             {character === 'MICROPHONE' ? (
@@ -26,9 +25,12 @@ const Card = ({ title, content, link, character }: AcademyDay) => (
         <h3 className={styles.title}>{title}</h3>
 
         <RichText theme="INDIGO" content={content} className={styles.content} />
+        {/*
         <Button url={link} theme="WHITE" className={styles.button} internal>
             Apply now
         </Button>
+        */}
+        <div className={styles.disabledButton}>Applications closed</div>
     </div>
 );
 


### PR DESCRIPTION
### Description of Changes Made

Removes the button for applying to the academy scheme, as applications for this have now closed. To reopen applications, add a new link to the academy day in Contentful. To close applications, remove the application link. I've added a note for how this works in the Contentful editor.

I decided to style a div for this instead of creating of passing another prop to the `Button` component: the button component already has several different style modifications applied to it. 

### How to Test

This page should show applications closed on the preview site as I've removed the application link.

[Link to changes made on preview site](https://careers-52kizw1li-careers-site.vercel.app/careers/academy)

### Screenshots

<details>
  <summary>Expand to show more</summary>
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/18164832/169780077-c73f618c-9af3-4dc0-bc31-67cb891b5bf7.png">
<img width="453" alt="image" src="https://user-images.githubusercontent.com/18164832/169780152-0a59c6a2-98b9-46a4-983a-6ed884cc6070.png">

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] Tests and linting passes.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.
