### PR TITLE
Fix Page caching

### DIFF
--- a/pages/api/jobs/[slug].ts
+++ b/pages/api/jobs/[slug].ts
@@ -2,11 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { JobPost } from 'lib/peopleHR';
 import { getAllJobPostings } from 'pages/api/_peopleHR';
 
-export async function getJobPost(
-    slug: string,
-): Promise<JobPost | undefined | null> {
-    const jobPostings: JobPost[] | null = await getAllJobPostings();
-    if (jobPostings === null) return null;
+export async function getJobPost(slug: string): Promise<JobPost | undefined> {
+    const jobPostings: JobPost[] = await getAllJobPostings();
     return jobPostings.find((post) => post.slug === slug);
 }
 

--- a/pages/api/jobs/slugs.ts
+++ b/pages/api/jobs/slugs.ts
@@ -7,9 +7,8 @@ import urls from 'lib/urls';
  * Used for generating pages in jobs/[slug].tsx
  * @returns an array of URL slugs for all the job posts.
  */
-export async function getAllJobSlugs(): Promise<string[] | null> {
-    const jobPostings: JobPost[] | null = await getAllJobPostings();
-    if (jobPostings === null) return null;
+export async function getAllJobSlugs(): Promise<string[]> {
+    const jobPostings: JobPost[] = await getAllJobPostings();
     return jobPostings.map((post) => `${urls.jobs}${post.slug}`);
 }
 

--- a/pages/api/jobs/summaries.ts
+++ b/pages/api/jobs/summaries.ts
@@ -8,8 +8,7 @@ import { getAllJobPostings } from 'pages/api/_peopleHR';
  * @returns an array of job summaries.
  */
 export async function getAllJobSummaries() {
-    const jobPostings: JobPost[] | null = await getAllJobPostings();
-    if (jobPostings === null) return null;
+    const jobPostings: JobPost[] = await getAllJobPostings();
     return jobPostings.map((post) => createJobSummaryFromPost(post));
 }
 

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -197,15 +197,10 @@ const Jobs: NextPage<JobsPageProps> = ({ preview, jobs, content }) => {
 export default Jobs;
 
 export async function getStaticProps({ preview = false }) {
-    try {
-        const jobs = await getAllJobSummaries();
-        const content = (await getJobListingPage(preview)) ?? [];
-        return {
-            props: { preview, jobs, content },
-            revalidate: 60 * 60, // After one hour, the cache expires and the page gets rebuilt.
-        };
-    } catch (error) {
-        // Next.js will display previously cached page instead of revalidating.
-        throw new Error('Failed to fetch People HR Job listings')
-    }
+    const jobs = await getAllJobSummaries();
+    const content = (await getJobListingPage(preview)) ?? [];
+    return {
+        props: { preview, jobs, content },
+        revalidate: 60 * 60, // After one hour, the cache expires and the page gets rebuilt.
+    };
 }

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -205,8 +205,7 @@ export async function getStaticProps({ preview = false }) {
             revalidate: 60 * 60, // After one hour, the cache expires and the page gets rebuilt.
         };
     } catch (error) {
-        return {
-            notFound: true,
-        };
+        // Next.js will display previously cached page instead of revalidating.
+        throw new Error('Failed to fetch People HR Job listings')
     }
 }

--- a/pages/jobs/[slug].tsx
+++ b/pages/jobs/[slug].tsx
@@ -112,24 +112,18 @@ export async function getStaticProps({
     params: { slug: string };
     preview: boolean;
 }) {
-    try {
-        const job = await getJobPost(params.slug);
-        const jobsAvailable = await getNumberOfActiveRoles();
-        const jobSlug = params.slug;
-        const content = await getJobPage(preview);
-        if (!job) {
-            return { notFound: true };
-        }
-
-        return {
-            props: { preview, job, jobsAvailable, content, jobSlug },
-            revalidate: 60 * 60, // After one hour, the cache expires and the page gets rebuilt.
-        };
-    } catch (error) {
-        return {
-            notFound: true,
-        };
+    const job = await getJobPost(params.slug);
+    const jobsAvailable = await getNumberOfActiveRoles();
+    const jobSlug = params.slug;
+    const content = await getJobPage(preview);
+    if (!job) {
+        return { notFound: true };
     }
+
+    return {
+        props: { preview, job, jobsAvailable, content, jobSlug },
+        revalidate: 60 * 60, // After one hour, the cache expires and the page gets rebuilt.
+    };
 }
 
 export async function getStaticPaths() {


### PR DESCRIPTION
### Description of Changes Made

Refactored the current approach of catching errors and returning null instead of throwing errors in PeopleHR API requests. The former logic has been causing Next.js's data fetching/rendering methods to return a 404 page, instead of relying on it's fallback caching to render the previous cached version of the page when we are unable to query PeopleHR (Note people HR's API is unreliable).

This will also mean that builds will fail when we can't fetch data from people HR which should be the correct behaviour. 

### How to Test

[Link to changes made on preview site](https://careers-e2qaoluoi-careers-site.vercel.app/careers/)

I tested locally by randomly throwing an error inside `fetchPeopleHRFeed` and using `npm run build && npm run start` in order to use caching (`npm run dev` will not use Next.js's caching).

```
/* eslint-disable no-console */
console.log("Fail to fetch people HR feed", new Date().getMinutes() % 2  === 0)
if (new Date().getMinutes() % 2  === 0) throw new Error('rand error');
```

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
