### PR TITLE
Remove peopleHR file caching

### DIFF
--- a/pages/api/_peopleHR.ts
+++ b/pages/api/_peopleHR.ts
@@ -1,15 +1,5 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
-import path from 'path';
 import xml2js from 'xml2js';
 import { JobPost, convertJSONToJobPosts } from 'lib/peopleHR';
-
-// Code based on the following tutorial
-// https://medium.com/@boris.poehland.business/next-js-api-routes-how-to-read-files-from-directory-compatible-with-vercel-5fb5837694b9
-
-// One hour, measured in milliseconds
-const CACHE_TTL = 60 * 60 * 1000;
-const CACHE_FOLDER = 'cachedData';
-const CACHE_FILENAME = 'peopleHRcache.json';
 
 /**
  * Converts XML to JSON using xml2js
@@ -47,84 +37,8 @@ async function fetchPeopleHRFeed(): Promise<string | null> {
     );
 }
 
-function writeToCache(
-    cacheFilePath: string,
-    fileData: { lastUpdated: number; jobs: any },
-) {
-    try {
-        // Check if cache folder exists before writing
-        const cacheFileFolder = path.resolve(process.cwd(), CACHE_FOLDER);
-        if (!existsSync(cacheFileFolder)) {
-            mkdirSync(cacheFileFolder);
-        }
-
-        writeFileSync(cacheFilePath, JSON.stringify(fileData));
-    } catch (error) {
-        console.error('Error writing to the PeopleHR cache file: ', error);
-    }
-}
-
-/**
- * Pulls the PeopleHR RSS feed data from the cache,
- * or fetches it from the feed if the cache has expired
- * @returns JSON of the RSS feed
- */
-async function getJobPostingData() {
-    const cacheFilePath = path.resolve(
-        process.cwd(),
-        CACHE_FOLDER,
-        CACHE_FILENAME,
-    );
-
-    if (existsSync(cacheFilePath)) {
-        let cache = {} as any;
-
-        try {
-            cache = JSON.parse(readFileSync(cacheFilePath, 'utf8'));
-        } catch (error) {
-            console.error(
-                'Error reading and parsing the PeopleHR cache file: ',
-                error,
-            );
-            cache.lastUpdated = 0; // Force a rewrite to the cache if the cache has become corrupted
-        }
-
-        if (cache.lastUpdated + CACHE_TTL < Date.now()) {
-            // The cache has timed out, fetch new data from PeopleHR
-
-            const peopleHRJobPostings = await fetchPeopleHRFeed();
-
-            // If the server responds OK, update according to the feed contents
-            const fileData = {
-                lastUpdated: Date.now(),
-                jobs: peopleHRJobPostings,
-            };
-
-            writeToCache(cacheFilePath, fileData);
-
-            return peopleHRJobPostings;
-        }
-
-        // The cache has not timed out yet, return the cached JSON
-        return cache.jobs;
-    }
-
-    // If the cache file doesn't exist, create one
-    const peopleHRJobPostings = await fetchPeopleHRFeed();
-
-    // Create a new file and set the cache
-    const fileData = {
-        lastUpdated: Date.now(),
-        jobs: peopleHRJobPostings,
-    };
-
-    writeToCache(cacheFilePath, fileData);
-
-    return peopleHRJobPostings;
-}
-
 export async function getAllJobPostings(): Promise<JobPost[]> {
-    const jobPostingData = await getJobPostingData();
+    const jobPostingData = await fetchPeopleHRFeed();
     return convertJSONToJobPosts(jobPostingData);
 }
 


### PR DESCRIPTION
### Description of Changes Made
The PR removes code used to cache (read/write) PeopleHR requests into a folder, and instead calls the API directly for every request.

The current caching method used for PeopleHR is no longer supported (results in a read-only file error). We could fix this however, removing the file caching seems to be a better option, this type of file caching does not seem to be offically supported by Vecel/Next.js ([ref](https://github.com/orgs/vercel/discussions/241)) and will likely result in similar issues in the future (in terms of upgrades and changes to Vercel).

Removing the file caching will result in a few extra requests to peopleHR when job pages need to revalidate, however the changes we also reduce a lot of technical debt.

### How to Test

Run Next.js in production, test Next.js's page caching works if peopleHR requests were to fail.

[Link to changes made on preview site]()


### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
