### PR TITLE
Remove benefits section for independent trustee role

### DIFF
--- a/pages/jobs/[slug].tsx
+++ b/pages/jobs/[slug].tsx
@@ -77,10 +77,14 @@ const JobPosting: NextPage<JobPageProps> = ({
                 />
             </div>
 
-            <Benefits
-                title={content.itemsCollection.items[0].benefitsTitle}
-                benefits={benefits}
-            />
+            {/* Independent trustees don't receive benefits. Todo: This code change was requested as an ad-hoc fix -
+                we could pull a list of job titles that don't receive benefits from the CMS in the future. */}
+            {job.title !== 'Independent Trustee' && (
+                <Benefits
+                    title={content.itemsCollection.items[0].benefitsTitle}
+                    benefits={benefits}
+                />
+            )}
 
             <div className={styles.contentContainer}>
                 <div className={styles.textContainer}>


### PR DESCRIPTION
## Summary

HR requested to remove the benefits section from the independent trustee role as it doesn't relate to it.

This is a temporary fix hardcoded specifically to this job title. I checked whether we could use the `Board` department value from PeopleHR to exclude this section, but HR advised against it for now.

In future we could export a list of roles that don't get benefits from Contentful, though that might be over-engineering a quick fix.

## How to Test

[Link to changes made on preview site]()

## Screenshots

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/18164832/212357608-7e033399-36cd-45e1-8fdd-e045ee9181bf.png">

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [ ] Tests and linting passes.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.
